### PR TITLE
Add uBlock Origin agent to filters.txt

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: Personal Clean-Web
 ! Checksum: asrBwjkGclcYuWN3xdU+Lw
 ! Description: List of filter rules for uBlock Origin to enhance the browsing privacy and replace Ghostery


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401